### PR TITLE
updated dynamic recipe page to look closer to static recipe page

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -165,17 +165,15 @@ Copied from  cs373-idb/db/scraped_data/recipes/african/african632003.json
 @app.route('/recipe.html')
 @app.route('/recipe_<r_id>.html')
 def recipe(r_id=None):
-	store = {"id":"1",
-	"instructions":"<ol><li>Saute onions in large pot until soft. Add all ingredients except for peanut butter and simmer for 1 1/2 hours. </li><li>Stir a spoonful of peanut butter into each serving.</li></ol>",
-	"ingredients":["a","<b>b</b>"],
-	"test_ingred":"1 teaspoon <a href=\"/2044.html\">basil</a>",
-	"ingred":4,
-	"title":"Jamba",
-	"recipeslit":"active",
-	"img_uri":"https://webknox.com/recipeImages/648427-556x370.jpg"}
+	store = RecipeQueries.getRecipeByID(r_id)
+	add_hrefs(store)
 	split_ingredients(store)
 	split_instructions(store)
 	return render_template('recipe.html', **store)
+
+def add_hrefs(d):
+    for ingredient in d["ingredients"]:
+        ingredient["href"] = "/ingredient_" + str(ingredient["id"]) + ".html"
 
 def split_ingredients(d):
 	l = d["ingredients"]

--- a/app/templates/recipe.html
+++ b/app/templates/recipe.html
@@ -55,7 +55,7 @@
 		<h1>{{ title }}</h1>
 	</div>
 	<div style="padding-top:10px" class="col-xs-12 col-sm-6 col-lg-6">
-		<img class="img-responsive" src={{ img_uri }}></img>
+		<img class="img-responsive" src={{ image_uri }}></img>
 	</div>
 	
 	<div class="page-header">
@@ -63,19 +63,22 @@
 	</div>
 	<div class="row">
 		<div class="col-xs-12 col-sm-6 col-lg-4">
-			<div class="checkbox">
-				<label><input type="checkbox" value="">{{test_ingred | safe}}</label>
-			</div>
 			{% for ingredient in ingredients1 %}
 			<div class="checkbox">
-				<label><input type="checkbox" value="">{{ingredient | safe}}</label>
+				<label>
+                    <input type="checkbox" value=""></input>
+                    <a href="{{ ingredient.href }}">{{ingredient.original_string | safe}}</a>
+                </label>
 			</div>
 			{% endfor %}
 		</div>
 		<div class="col-xs-12 col-sm-6 col-lg-4">
 			{% for ingredient in ingredients2 %}
 			<div class="checkbox">
-				<label><input type="checkbox" value="">{{ingredient | safe}}</label>
+				<label>
+                    <input type="checkbox" value=""></input>
+                    <a href="{{ ingredient.href }}">{{ingredient.original_string | safe}}</a>
+                </label>
 			</div>
 			{% endfor %}
 		</div>


### PR DESCRIPTION
A couple of issues 

1. IngredientsInRecipes does simply have an ingredient name. So I made the link the whole string ('original_string')

2. Different recipes have different image sizes. For example, /recipe_6.html vs. /recipe_8.html

## static example 
![1](https://cloud.githubusercontent.com/assets/3394986/14309732/e9ace6e2-fba3-11e5-8fb1-d75dabcee950.JPG)

## dynamic recipe 6
![6](https://cloud.githubusercontent.com/assets/3394986/14309711/b9ff368e-fba3-11e5-9bac-18610464e5ce.JPG)

## dynamic recipe 8
![8](https://cloud.githubusercontent.com/assets/3394986/14309712/bbf9024e-fba3-11e5-9dee-e8a303e5dfa4.JPG)
